### PR TITLE
State module has been completed

### DIFF
--- a/example/src/test/scala/monocle/state/StateExample.scala
+++ b/example/src/test/scala/monocle/state/StateExample.scala
@@ -72,6 +72,52 @@ class StateExample extends MonocleSuite {
   val _oldAge = Optional[Person, Int](p => if (p.age > 50) Some(p.age) else None){ a => _.copy(age = a) }
   val _coolGuy = Optional[Person, String](p => if (p.name.startsWith("C")) Some(p.name) else None){ n => _.copy(name = n) }
 
+  test("extract for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = _oldAge extract
+
+    update.run(youngPerson) shouldEqual ((Person("John", 30), None))
+  }
+
+  test("extract for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = _oldAge extract
+
+    update.run(oldPerson) shouldEqual ((Person("John", 100), Some(100)))
+  }
+
+  test("extracts for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = _oldAge extracts (_ * 2)
+
+    update.run(youngPerson) shouldEqual ((Person("John", 30), None))
+  }
+
+  test("extracts for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = _oldAge extracts (_ * 2)
+
+    update.run(oldPerson) shouldEqual ((Person("John", 100), Some(200)))
+  }
+
+  test("mod for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = for {
+      i <- _oldAge mod (_ + 1)
+    } yield i
+
+    update.run(youngPerson) shouldEqual ((Person("John", 30), None))
+  }
+
+  test("mod for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = for {
+      i <- _oldAge mod (_ + 1)
+    } yield i
+
+    update.run(oldPerson) shouldEqual ((Person("John", 101), Some(101)))
+  }
+
   test("modo for Optional (predicate is false)"){
     val youngPerson = Person("John", 30)
     val update = for {
@@ -110,4 +156,67 @@ class StateExample extends MonocleSuite {
     update.run(oldCoolPerson) shouldEqual ((Person("chris", 30), Some("Chris")))
   }
 
+  test("modi for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = _oldAge modi (_ + 1)
+
+    update.run(youngPerson) shouldEqual ((Person("John", 30), ()))
+  }
+
+  test("modi for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = _oldAge modi (_ + 1)
+
+    update.run(oldPerson) shouldEqual ((Person("John", 101), ()))
+  }
+
+  test("assign for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = for {
+      i <- _oldAge assign 30
+    } yield i
+
+    update.run(oldPerson) shouldEqual ((Person("John", 30), Some(30)))
+  }
+
+  test("assign for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = for {
+      i <- _oldAge assign 100
+    } yield i
+
+    update.run(youngPerson) shouldEqual ((Person("John", 100), Some(100)))
+  }
+
+  test("assigno for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = for {
+      i <- _oldAge assigno 30
+    } yield i
+
+    update.run(oldPerson) shouldEqual ((Person("John", 30), Some(100)))
+  }
+
+  test("assigno for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = for {
+      i <- _oldAge assigno 100
+    } yield i
+
+    update.run(youngPerson) shouldEqual ((Person("John", 100), None))
+  }
+
+  test("assigni for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = _oldAge assigni 30
+
+    update.run(oldPerson) shouldEqual ((Person("John", 30),()))
+  }
+
+  test("assigni for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = _oldAge assigni 100
+
+    update.run(youngPerson) shouldEqual ((Person("John", 100), ()))
+  }
 }

--- a/example/src/test/scala/monocle/state/StateExample.scala
+++ b/example/src/test/scala/monocle/state/StateExample.scala
@@ -9,6 +9,22 @@ class StateExample extends MonocleSuite {
   val _age = GenLens[Person](_.age)
   val p = Person("John", 30)
 
+  test("extract"){
+    val getAge = for {
+      i <- _age extract
+    } yield i
+
+    getAge.run(p) shouldEqual ((Person("John", 30), 30))
+  }
+
+  test("extracts"){
+    val getDoubleAge = for {
+      i <- _age extracts (_ * 2)
+    } yield i
+
+    getDoubleAge.run(p) shouldEqual ((Person("John", 30), 60))
+  }
+
   test("mod"){
     val increment = for {
       i <- _age mod (_ + 1)

--- a/example/src/test/scala/monocle/state/StateExample.scala
+++ b/example/src/test/scala/monocle/state/StateExample.scala
@@ -25,6 +25,12 @@ class StateExample extends MonocleSuite {
     increment.run(p) shouldEqual ((Person("John", 31), 30))
   }
 
+  test("modi"){
+    val increment = _age modi (_ + 1)
+
+    increment.run(p) shouldEqual ((Person("John", 31), ()))
+  }
+
   test("assign"){
     val set20 = for {
       i <- _age assign 20
@@ -39,6 +45,12 @@ class StateExample extends MonocleSuite {
     } yield i
 
     set20.run(p) shouldEqual ((Person("John", 20), 30))
+  }
+
+  test("assigni"){
+    val set20 = _age assigni 20
+
+    set20.run(p) shouldEqual ((Person("John", 20), ()))
   }
 
   val _oldAge = Optional[Person, Int](p => if (p.age > 50) Some(p.age) else None){ a => _.copy(age = a) }

--- a/state/shared/src/main/scala/monocle/state/StateLensSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateLensSyntax.scala
@@ -41,7 +41,7 @@ final class StateLensOps[S, T, A, B](lens: PLens[S, T, A, B]) {
 
   /** modify the value viewed through the lens and ignores both values */
   def modi(f: A => B): IndexedState[S, T, Unit] =
-    mod(f) >| (())
+    IndexedState(s => (lens.modify(f)(s), ()))
 
   /** set the value viewed through the lens and returns its *new* value */
   def assign(b: B): IndexedState[S, T, B] =

--- a/state/shared/src/main/scala/monocle/state/StateLensSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateLensSyntax.scala
@@ -25,7 +25,7 @@ final class StateLensOps[S, T, A, B](lens: PLens[S, T, A, B]) {
 
   /** extracts the value viewed through the lens and applies `f` over it */
   def extracts[B](f: A => B): State[S, B] =
-    toState.map(f)
+    extract.map(f)
 
   /** modify the value viewed through the lens and returns its *new* value */
   def mod(f: A => B): IndexedState[S, T, B] =

--- a/state/shared/src/main/scala/monocle/state/StateLensSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateLensSyntax.scala
@@ -19,6 +19,14 @@ final class StateLensOps[S, T, A, B](lens: PLens[S, T, A, B]) {
   def st: State[S, A] =
     toState
 
+  /** extracts the value viewed through the lens */
+  def extract: State[S, A] =
+    toState
+
+  /** extracts the value viewed through the lens and applies `f` over it */
+  def extracts[B](f: A => B): State[S, B] =
+    toState.map(f)
+
   /** modify the value viewed through the lens and returns its *new* value */
   def mod(f: A => B): IndexedState[S, T, B] =
     IndexedState(s => {

--- a/state/shared/src/main/scala/monocle/state/StateLensSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateLensSyntax.scala
@@ -3,6 +3,7 @@ package monocle.state
 import monocle.PLens
 
 import scalaz.{IndexedState, State}
+import scalaz.syntax.functor._
 
 trait StateLensSyntax {
   implicit def toStateLensOps[S, T, A, B](lens: PLens[S, T, A, B]): StateLensOps[S, T, A, B] =
@@ -30,6 +31,10 @@ final class StateLensOps[S, T, A, B](lens: PLens[S, T, A, B]) {
   def modo(f: A => B): IndexedState[S, T, A] =
     toState.leftMap(lens.modify(f))
 
+  /** modify the value viewed through the lens and ignores both values */
+  def modi(f: A => B): IndexedState[S, T, Unit] =
+    mod(f) >| (())
+
   /** set the value viewed through the lens and returns its *new* value */
   def assign(b: B): IndexedState[S, T, B] =
     mod(_ => b)
@@ -37,4 +42,8 @@ final class StateLensOps[S, T, A, B](lens: PLens[S, T, A, B]) {
   /** set the value viewed through the lens and returns its *old* value */
   def assigno(b: B): IndexedState[S, T, A] =
     modo(_ => b)
+
+  /** set the value viewed through the lens and ignores both values */
+  def assigni(b: B): IndexedState[S, T, Unit] =
+    modi(_ => b)
 }

--- a/state/shared/src/main/scala/monocle/state/StateOptionalSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateOptionalSyntax.scala
@@ -18,11 +18,35 @@ final class StateOptionalOps[S, T, A, B](optional: POptional[S, T, A, B]) {
   def st: State[S, Option[A]] =
     toState
 
+    /** extracts the value viewed through the optional */
+  def extract: State[S, Option[A]] =
+    toState
+
+  /** extracts the value viewed through the optional and applies `f` over it */
+  def extracts[B](f: A => B): State[S, Option[B]] =
+    extract.map(_.map(f))
+
+  /** modify the value viewed through the Optional and return its *new* value, if there is one */
+  def mod(f: A => B): IndexedState[S, T, Option[B]] =
+    IndexedState(s => (optional.modify(f)(s), optional.getOption(s).map(f)))
+
   /** modify the value viewed through the Optional and return its *old* value, if there was one */
   def modo(f: A => B): IndexedState[S, T, Option[A]] =
     IndexedState(s => (optional.modify(f)(s), optional.getOption(s)))
 
-  /** set the value viewed through the Optional and return its *old* value, if there was one */
-  def assigno(b: B): IndexedState[S, T, Option[A]] = modo(_ => b)
+  /** modify the value viewed through the Optional and ignores both values */
+  def modi(f: A => B): IndexedState[S, T, Unit] =
+    IndexedState(s => (optional.modify(f)(s), ()))
 
+  /** set the value viewed through the Optional and returns its *new* value */
+  def assign(b: B): IndexedState[S, T, Option[B]] =
+    IndexedState(s => (optional.set(b)(s), Option(b)))
+
+  /** set the value viewed through the Optional and return its *old* value, if there was one */
+  def assigno(b: B): IndexedState[S, T, Option[A]] =
+    IndexedState(s => (optional.set(b)(s), optional.getOption(s)))
+
+  /** set the value viewed through the Optional and ignores both values */
+  def assigni(b: B): IndexedState[S, T, Unit] =
+    IndexedState(s => (optional.set(b)(s), ()))
 }


### PR DESCRIPTION
Added `modi` and `assigni` methods to the _state_ module. While `mod` and `modo` are quite practical to get the new and old values, respectively, I was missing a function to ignore them. The new method `modi` ignores both new and old values and just returns `Unit`. Same idea was applied to `assign(o)`, resulting in `assigni`.

As an example, consider the migration of some pure _State_ logic into Monocle, taking into account that `State.put` and consequently `State.modify` do return `Unit` values as output:

``` scala
case class Person(name: String, age: Int)

// Legacy state-based logic that we want to migrate to Monocle

val increment0: State[Person, Unit] =
  modify(p => p.copy(age = p.age + 1))

// Since `State.{ modify, put }` returns `Unit`, we need to adapt mod's output
// to return it as well.

val _age = GenLens[Person](_.age)

val increment1: State[Person, Unit] =
  (_age mod (_ + 1)) >| (()) // and it's quite ugly

// A simple `modi` method let us avoid the boilerplate.

val increment2: State[Person, Unit] =
  _age modi (_ + 1)
```

The last lines show the final migrated code using the proposed method `modi`.
