### PR TITLE
State module support for Getter and Setter

### DIFF
--- a/example/src/test/scala/monocle/state/StateExample.scala
+++ b/example/src/test/scala/monocle/state/StateExample.scala
@@ -1,6 +1,6 @@
 package monocle.state
 
-import monocle.{MonocleSuite, Optional}
+import monocle.{MonocleSuite, Optional, Setter, Getter}
 import monocle.macros.GenLens
 
 class StateExample extends MonocleSuite {
@@ -218,5 +218,33 @@ class StateExample extends MonocleSuite {
     val update = _oldAge assigni 100
 
     update.run(youngPerson) shouldEqual ((Person("John", 100), ()))
+  }
+
+  val _nameSet = Setter[Person, String](f => p => p.copy(name = f(p.name)))
+
+  test("modi for Setter") {
+    val toUpper = _nameSet modi (_.toUpperCase)
+
+    toUpper.run(p) shouldEqual ((Person("JOHN", 30), ()))
+  }
+
+  test("assigni for Setter") {
+    val toUpper = _nameSet assigni ("Juan")
+
+    toUpper.run(p) shouldEqual ((Person("Juan", 30), ()))
+  }
+
+  val _nameGet = Getter[Person, String](_.name)
+
+  test("extract for Getter") {
+    val name = _nameGet extract
+
+    name.run(p) shouldEqual ((Person("John", 30), "John"))
+  }
+
+  test("extracts for Getter") {
+    val upper = _nameGet extracts (_.toUpperCase)
+
+    upper.run(p) shouldEqual ((Person("John", 30), "JOHN"))
   }
 }

--- a/state/shared/src/main/scala/monocle/state/All.scala
+++ b/state/shared/src/main/scala/monocle/state/All.scala
@@ -1,3 +1,6 @@
 package monocle.state
 
-object all extends StateLensSyntax with StateOptionalSyntax
+object all extends StateLensSyntax
+  with StateOptionalSyntax
+  with StateGetterSyntax
+  with StateSetterSyntax

--- a/state/shared/src/main/scala/monocle/state/StateGetterSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateGetterSyntax.scala
@@ -1,0 +1,28 @@
+package monocle.state
+
+import monocle.Getter
+
+import scalaz.{IndexedState, State}
+
+trait StateGetterSyntax {
+  implicit def toStateGetterOps[S, A](getter: Getter[S, A]): StateGetterOps[S, A] =
+    new StateGetterOps[S, A](getter)
+}
+
+final class StateGetterOps[S, A](getter: Getter[S, A]) {
+  /** transforms a Getter into a State */
+  def toState: State[S, A] =
+    State(s => (s, getter.get(s)))
+
+  /** alias for toState */
+  def st: State[S, A] =
+    toState
+
+  /** extracts the value viewed through the getter */
+  def extract: State[S, A] =
+    toState
+
+  /** extracts the value viewed through the getter and applies `f` over it */
+  def extracts[B](f: A => B): State[S, B] =
+    extract.map(f)
+}

--- a/state/shared/src/main/scala/monocle/state/StateSetterSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateSetterSyntax.scala
@@ -1,0 +1,20 @@
+package monocle.state
+
+import monocle.PSetter
+
+import scalaz.{IndexedState, State}
+
+trait StateSetterSyntax {
+  implicit def toStateSetterOps[S, T, A, B](setter: PSetter[S, T, A, B]): StateSetterOps[S, T, A, B] =
+    new StateSetterOps[S, T, A, B](setter)
+}
+
+final class StateSetterOps[S, T, A, B](setter: PSetter[S, T, A, B]) {
+  /** modify the value referenced through the setter */
+  def modi(f: A => B): IndexedState[S, T, Unit] =
+    IndexedState(s => (setter.modify(f)(s), ()))
+
+  /** set the value referenced through the setter */
+  def assigni(b: B): IndexedState[S, T, Unit] =
+    modi(_ => b)
+}

--- a/test/shared/src/test/scala/monocle/MonocleSuite.scala
+++ b/test/shared/src/test/scala/monocle/MonocleSuite.scala
@@ -3,7 +3,7 @@ package monocle
 import monocle.function.GenericOptics
 import monocle.generic.GenericInstances
 import monocle.refined.RefinedInstances
-import monocle.state.{StateLensSyntax, StateOptionalSyntax}
+import monocle.state.{StateLensSyntax, StateOptionalSyntax, StateGetterSyntax, StateSetterSyntax}
 import monocle.std.StdInstances
 import monocle.syntax.Syntaxes
 import org.scalatest.{FunSuite, Matchers}
@@ -20,3 +20,5 @@ trait MonocleSuite extends FunSuite
                       with Syntaxes
                       with StateLensSyntax
                       with StateOptionalSyntax
+                      with StateGetterSyntax
+                      with StateSetterSyntax


### PR DESCRIPTION
The state module does now support `Getter`s and `Setter`s. As a result, we created *StateGetterSyntax* (with methods `extract` and `extracts`) and *StateSetterSyntax* (with methods `modi` and `assigni`).